### PR TITLE
handle bytes vs str for the token returned by jwt.encode()

### DIFF
--- a/requests_jwt.py
+++ b/requests_jwt.py
@@ -162,6 +162,8 @@ class JWTAuth(AuthBase):
         payload = self._generate(request)
         #import pdb; pdb.set_trace()
         token = jwt.encode(payload, self.secret, self.alg)
-    
-        request.headers['Authorization'] = self._header_format % token.decode('ascii')
+        
+        # jwt.encode() -> str in pyJWT>=2, vs bytes in pyJWT<2
+        token_str = token.decode('ascii') if isinstance(token, bytes) elses token
+        request.headers['Authorization'] = self._header_format % token_str
         return request

--- a/requests_jwt.py
+++ b/requests_jwt.py
@@ -164,6 +164,6 @@ class JWTAuth(AuthBase):
         token = jwt.encode(payload, self.secret, self.alg)
         
         # jwt.encode() -> str in pyJWT>=2, vs bytes in pyJWT<2
-        token_str = token.decode('ascii') if isinstance(token, bytes) elses token
+        token_str = token.decode('ascii') if isinstance(token, bytes) else token
         request.headers['Authorization'] = self._header_format % token_str
         return request


### PR DESCRIPTION
Hi @tgs 

This has been reported as a problem here: https://github.com/pycontribs/jira/issues/1069

This proposal is fully compatible with both versions, and technically both `jwt` and `pyjwt` (yep, unfortunately there are two packages with conflicting namespaces)